### PR TITLE
Switch test runner to pytest

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -7,7 +7,7 @@ python -m pip install --upgrade pip
 
 # Install runtime and test dependencies
 pip install \
-  nose \
+  pytest \
   pg8000 \
   psycopg2-binary \
   SQLAlchemy \

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,11 @@ setup(
     install_requires=install_requires,
     extras_require=dict(
         testing=[
-            'nose',
+            'pytest',
             'psycopg2',
             'SQLAlchemy',
         ],
     ),
-    test_suite='nose.collector',
+    test_suite='pytest',
     namespace_packages=['testing'],
 )

--- a/src/testing/__init__.py
+++ b/src/testing/__init__.py
@@ -13,4 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__import__('pkg_resources').declare_namespace(__name__)
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:  # pragma: no cover - fallback when pkg_resources is missing
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,14 @@ envlist=py39,py310,py311,py312
 
 [testenv]
 deps=
-    nose
+    pytest
     flake8
     psycopg
     SQLAlchemy
 passenv=
     TRAVIS*
 commands=
-    nosetests
+    pytest
     flake8 --exclude=.tox/
 
 [testenv:coverage]
@@ -19,5 +19,5 @@ deps=
     coverage
     coveralls
 commands=
-    nosetests --with-coverage --cover-package=testing
+    pytest --cov=testing
     coveralls


### PR DESCRIPTION
## Summary
- swap out nose for pytest in setup and automation
- add pkg_resources fallback so tests import without setuptools

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg')*